### PR TITLE
fix: add proper validation for repositoryFilter in notification profile DTOs

### DIFF
--- a/app/src/common/dtos/notification-profile.dto.ts
+++ b/app/src/common/dtos/notification-profile.dto.ts
@@ -14,9 +14,19 @@ import { Transform, Type } from 'class-transformer';
 import type {
   DigestScopeType,
   DigestDeliveryType,
-  RepositoryFilter,
 } from '../types/digest.types';
 import type { NotificationPreferences } from '../types/user.types';
+
+export class RepositoryFilterDto {
+  @IsString()
+  @IsEnum(['all', 'selected'])
+  type: 'all' | 'selected';
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  repoIds?: string[];
+}
 
 export class CreateNotificationProfileDto {
   @IsString()
@@ -41,8 +51,8 @@ export class CreateNotificationProfileDto {
 
   @IsObject()
   @ValidateNested()
-  @Type(() => Object)
-  repositoryFilter: RepositoryFilter;
+  @Type(() => RepositoryFilterDto)
+  repositoryFilter: RepositoryFilterDto;
 
   @IsString()
   @IsEnum(['dm', 'channel'])
@@ -96,8 +106,8 @@ export class UpdateNotificationProfileDto {
   @IsOptional()
   @IsObject()
   @ValidateNested()
-  @Type(() => Object)
-  repositoryFilter?: RepositoryFilter;
+  @Type(() => RepositoryFilterDto)
+  repositoryFilter?: RepositoryFilterDto;
 
   @IsOptional()
   @IsString()


### PR DESCRIPTION
## Summary
- Fixes 400 validation error when creating notification profiles
- Creates `RepositoryFilterDto` class with proper validation decorators  
- Replaces generic `Object` type with strongly-typed `RepositoryFilterDto`

## Test plan
- [x] Create notification profile with repositoryFilter type 'all'
- [x] Create notification profile with repositoryFilter type 'selected' with repoIds
- [x] Verify validation errors are resolved
- [x] Test both CreateNotificationProfileDto and UpdateNotificationProfileDto

🤖 Generated with [Claude Code](https://claude.ai/code)