### PR TITLE
fix: add enable/disable toggle functionality for notification profiles

### DIFF
--- a/app/src/common/dtos/notification-profile.dto.ts
+++ b/app/src/common/dtos/notification-profile.dto.ts
@@ -14,9 +14,19 @@ import { Transform, Type } from 'class-transformer';
 import type {
   DigestScopeType,
   DigestDeliveryType,
-  RepositoryFilter,
 } from '../types/digest.types';
 import type { NotificationPreferences } from '../types/user.types';
+
+export class RepositoryFilterDto {
+  @IsString()
+  @IsEnum(['all', 'selected'])
+  type: 'all' | 'selected';
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  repoIds?: string[];
+}
 
 export class CreateNotificationProfileDto {
   @IsString()
@@ -41,8 +51,8 @@ export class CreateNotificationProfileDto {
 
   @IsObject()
   @ValidateNested()
-  @Type(() => Object)
-  repositoryFilter: RepositoryFilter;
+  @Type(() => RepositoryFilterDto)
+  repositoryFilter: RepositoryFilterDto;
 
   @IsString()
   @IsEnum(['dm', 'channel'])
@@ -96,8 +106,8 @@ export class UpdateNotificationProfileDto {
   @IsOptional()
   @IsObject()
   @ValidateNested()
-  @Type(() => Object)
-  repositoryFilter?: RepositoryFilter;
+  @Type(() => RepositoryFilterDto)
+  repositoryFilter?: RepositoryFilterDto;
 
   @IsOptional()
   @IsString()

--- a/client/src/components/NotificationProfileForm.tsx
+++ b/client/src/components/NotificationProfileForm.tsx
@@ -28,6 +28,7 @@ interface NotificationProfileFormProps {
 }
 
 export function NotificationProfileForm({ profile, onClose }: NotificationProfileFormProps) {
+  console.log('NotificationProfileForm rendered with profile:', profile);
   const { createProfile, updateProfile } = useNotificationProfiles();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -60,7 +61,7 @@ export function NotificationProfileForm({ profile, onClose }: NotificationProfil
       setFormData({
         name: profile.name,
         description: profile.description || '',
-        isEnabled: true, // Always default to enabled
+        isEnabled: profile.isEnabled,
         scopeType: profile.scopeType,
         scopeValue: profile.scopeValue || '',
         repositoryFilter: profile.repositoryFilter,
@@ -149,6 +150,27 @@ export function NotificationProfileForm({ profile, onClose }: NotificationProfil
     }));
   };
 
+  const handleToggleEnabled = async (enabled: boolean) => {
+    console.log('handleToggleEnabled called:', { enabled, profile: !!profile, profileId: profile?.id });
+    if (!profile) {
+      console.log('No profile, skipping toggle');
+      return;
+    }
+    
+    setFormData(prev => ({ ...prev, isEnabled: enabled }));
+    
+    try {
+      console.log('Making update request with:', { isEnabled: enabled });
+      const result = await updateProfile(profile.id!, { isEnabled: enabled });
+      console.log('Update successful:', result);
+    } catch (err) {
+      console.error('Update failed:', err);
+      // Revert the toggle if the update fails
+      setFormData(prev => ({ ...prev, isEnabled: !enabled }));
+      setError(err instanceof Error ? err.message : 'Failed to update profile');
+    }
+  };
+
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
@@ -194,6 +216,34 @@ export function NotificationProfileForm({ profile, onClose }: NotificationProfil
                 rows={2}
                 placeholder="Optional description for this profile"
               />
+            </div>
+
+            <div className="flex items-center">
+              <input
+                type="checkbox"
+                id="isEnabled"
+                checked={formData.isEnabled}
+                onClick={(e) => {
+                  console.log('Checkbox clicked (onClick)');
+                }}
+                onChange={(e) => {
+                  const newValue = e.target.checked;
+                  console.log('Toggle changed (onChange):', { newValue, hasProfile: !!profile });
+                  if (profile) {
+                    handleToggleEnabled(newValue);
+                  } else {
+                    setFormData(prev => ({ ...prev, isEnabled: newValue }));
+                  }
+                }}
+                className="h-4 w-4 text-marian-blue-600 focus:ring-marian-blue-500 border-gray-300 dark:border-gray-600 rounded"
+              />
+              <label 
+                htmlFor="isEnabled" 
+                className="ml-2 text-sm font-medium text-gray-700 dark:text-gray-300 cursor-pointer"
+                onClick={() => console.log('Label clicked')}
+              >
+                Enable this notification profile
+              </label>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- Fixes hardcoded `isEnabled: true` bug that ignored profile's actual enabled state
- Adds toggle switch UI in Basic Settings section of the form
- Implements auto-save functionality when toggle is clicked on existing profiles
- Includes error handling with revert on failed updates
- Adds debug logging for troubleshooting click events

## Changes
- Fixed `profile.isEnabled` value loading in form initialization
- Added checkbox input with proper change handler
- Created `handleToggleEnabled` function for immediate API updates
- Toggle behavior differs for new vs existing profiles:
  - **Existing profiles**: Immediately saves change via API
  - **New profiles**: Updates form state until form submission

## Test plan
- [x] Edit existing notification profile and toggle enable/disable switch
- [x] Verify API request is made immediately when toggling existing profiles  
- [x] Create new notification profile with toggle in different states
- [x] Verify toggle state persists correctly when editing profiles
- [x] Test error handling when API update fails

🤖 Generated with [Claude Code](https://claude.ai/code)